### PR TITLE
bcp00302: add guidance for handling IS-04/IS-07 WebSockets

### DIFF
--- a/docs/1.0. Authorization Practice.md
+++ b/docs/1.0. Authorization Practice.md
@@ -76,7 +76,7 @@ For example, access to the following subscription would require token claims as 
 #### WebSocket Authorization
 
 When connecting to an [IS-07][] WebSocket, the JSON Web Token used MUST be validated to ensure it contains a read claim
-matching all Source data which may be returned by the WebSocket. These Source paths match those used by the IS-07 API.
+matching all Source data which may be returned by the WebSocket. These Source paths match those used by the IS-07 Events API.
 
 For example, access to the IS-07 Source IDs '9f463872-9621-4939-aa3a-dc3c82d8578b' and
 '7f87027c-ebb4-4640-b878-14952915249a' only would require token claims as follows.

--- a/docs/1.0. Authorization Practice.md
+++ b/docs/1.0. Authorization Practice.md
@@ -18,6 +18,8 @@ implement specific NMOS Interface Specifications.
 
 ### IS-04 - Discovery and Registration
 
+#### Client Authorization
+
 When registering resources with an instance of an [IS-04 Registry][], the Registry MUST capture the Client ID of the
 client performing the initial 'node' resource type registration. The Client ID can be found within the `client_id` claim
 of the valid JWT access token used in the HTTP request. Where the `client_id` is not specified the same identifier can
@@ -31,10 +33,68 @@ the Resource server rejecting the request with a '403' HTTP response code and a 
 error value of `insufficient_scope` as specified in [RFC 6750][RFC-6750]. All IS-04 resources can be related back to a
 single Node ID by following the [IS-04 Referential Integrity][] guide.
 
+#### WebSocket Authorization
+
+When creating an [IS-04 Registry][] WebSocket subscription, whether by using a POST to the `/subscriptions` resource
+or by using an `Upgrade` HTTP header, the JSON Web Token used MUST be validated to ensure it contains a write claim
+matching the subscriptions path, for example:
+
+```
+"x-nmos-query": {
+  "write": ["subscriptions"],
+  "read": ["*"]
+}
+```
+
+When connecting to an [IS-04 Registry][] WebSocket subscription, the JSON Web Token used MUST be validated to ensure it
+contains a read claim matching all data which may be returned according to the subscription's `resource_path`
+configuration. Note that the `resource_path` includes a leading slash where token claims do not. The `ws_href` path
+MUST NOT be validated against the token claims.
+
+For example, access to the following subscription would require token claims as follows:
+
+```
+{
+  "max_update_rate_ms": 100,
+  "resource_path": "/receivers",
+  "params": {},
+  "persist": false,
+  "secure": false,
+  "ws_href": "wss://172.29.80.52:8870/ws/?uid=6a52dbd5-a737-4c4e-823f-909ade8f8bf4",
+  "id": "6a52dbd5-a737-4c4e-823f-909ade8f8bf4"
+}
+```
+
+```
+"x-nmos-query": {
+  "read": ["receivers/*"]
+}
+```
+
+### IS-07 - Event and Tally
+
+#### WebSocket Authorization
+
+When connecting to an [IS-07][] WebSocket, the JSON Web Token used MUST be validated to ensure it contains a read claim
+matching all Source data which may be returned by the WebSocket. These Source paths match those used by the IS-07 API.
+
+For example, access to the IS-07 Source IDs '9f463872-9621-4939-aa3a-dc3c82d8578b' and
+'7f87027c-ebb4-4640-b878-14952915249a' only would require token claims as follows.
+
+```
+"x-nmos-events": {
+  "read": ["sources/9f463872-9621-4939-aa3a-dc3c82d8578b",
+           "sources/7f87027c-ebb4-4640-b878-14952915249a"]
+}
+```
+
+Specific token claims are not required in order to send IS-07 WebSocket commands such as 'subscription' and 'health',
+provided the token covers the 'events' scope and includes claims for any Sources which are being requested.
+
+
 [IS-10]: https://amwa-tv.github.io/nmos-authorization/branches/v1.0-dev/ "AMWA IS-10 NMOS Authorization API"
 [RFC-2119]: https://tools.ietf.org/html/rfc2119 "Key words for use in RFCs to Indicate Requirement Levels"
 [RFC-6750]: https://tools.ietf.org/html/rfc6750 "The OAuth 2.0 Authorization Framework: Bearer Token Usage"
-
 [IS-04 Registry]: http://amwa-tv.github.io/nmos-discovery-registration/ "AMWA IS-04 NMOS Discovery and Registration Specification"
-
 [IS-04 Referential Integrity]: https://amwa-tv.github.io/nmos-discovery-registration/tags/v1.3/docs/4.1._Behaviour_-_Registration.html#referential-integrity "AMWA IS-04 Resource Referential Integrity"
+[IS-07]: http://amwa-tv.github.io/nmos-event-tally/ "AMWA IS-07 NMOS Event and Tally Specification"

--- a/docs/1.0. Authorization Practice.md
+++ b/docs/1.0. Authorization Practice.md
@@ -88,6 +88,14 @@ For example, access to the IS-07 Source IDs '9f463872-9621-4939-aa3a-dc3c82d8578
 }
 ```
 
+Alternatively, access to all IS-07 Source IDs may be requested with a token claim as follows.
+
+```
+"x-nmos-events": {
+  "read": ["sources/*"]
+}
+```
+
 Specific token claims are not required in order to send IS-07 WebSocket commands such as 'subscription' and 'health',
 provided the token covers the 'events' scope and includes claims for any Sources which are being requested.
 


### PR DESCRIPTION
Resolves #3

NB: This is currently based on top of the 403 PR and will need moving if that is merged first.

This would benefit from review by someone more familiar with IS-07, and consideration of whether IS-04 subscription 'params' should also be factored into the validation process.