### PR TITLE
Add IS-specific scope requirements for client credentials use

### DIFF
--- a/docs/1.0. Authorization Practice.md
+++ b/docs/1.0. Authorization Practice.md
@@ -11,7 +11,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ## Scope
 
 The [AMWA IS-10 Specification](https://amwa-tv.github.io/nmos-authorization) describes how to implement a general OAuth
-2.0 authentication system, in line with current best practices. This document outlines additional requirements placed
+2.0 authorization system, in line with current best practices. This document outlines additional requirements placed
 upon Resource Servers and Clients which implement or interact with specific NMOS Interface Specifications.
 
 ## Authorization Grant Constraints

--- a/docs/1.0. Authorization Practice.md
+++ b/docs/1.0. Authorization Practice.md
@@ -10,9 +10,24 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Scope
 
-The [AMWA IS-10 Specification](https://amwa-tv.github.io/nmos-authorization) describes how to implement a general OAuth 2.0 authentication system, in
-line with current best practices. This document outlines additional requirements placed upon Resource Servers which
-implement specific NMOS Interface Specifications.
+The [AMWA IS-10 Specification](https://amwa-tv.github.io/nmos-authorization) describes how to implement a general OAuth
+2.0 authentication system, in line with current best practices. This document outlines additional requirements placed
+upon Resource Servers and Clients which implement or interact with specific NMOS Interface Specifications.
+
+## Authorization Grant Constraints
+
+As identified in IS-10, Authorization Clients are expected to use the Authorization Code OAuth grant type unless they
+are a confidential client which needs to peform machine to machine operations with no user interaction. Client
+interactions which MAY use the Client Credentials grant are detailed below.
+
+* IS-04 Node interactions with an IS-04 registry using the 'registration' scope
+* IS-07 WebSocket Receivers which are required to present a token to an IS-07 WebSocket Sender using the 'events' scope
+
+Alternative uses of the Client Credentials grant MUST be arranged on a deployment specific basis and MUST NOT form the
+default mode of operation.
+
+Authorization Servers SHOULD be configured to enforce the scopes which are permitted to use Client Credentials during
+the dynamic client registration or token exchange process where supported.
 
 ## NMOS APIs
 

--- a/docs/1.0. Authorization Practice.md
+++ b/docs/1.0. Authorization Practice.md
@@ -23,6 +23,8 @@ interactions which MAY use the Client Credentials grant are detailed below.
 * IS-04 Node interactions with an IS-04 registry using the 'registration' scope
 * IS-07 WebSocket Receivers which are required to present a token to an IS-07 WebSocket Sender using the 'events' scope
 
+The above list will be added to in the future if additional use cases for client credentials are identified.
+
 Alternative uses of the Client Credentials grant MUST be arranged on a deployment specific basis and MUST NOT form the
 default mode of operation.
 


### PR DESCRIPTION
Subject to the outcome of https://github.com/AMWA-TV/nmos-authorization/issues/76 and https://github.com/AMWA-TV/nmos-authorization/pull/77 this may be required.