### PR TITLE
Add a Table of Contents as per other single-page specs

### DIFF
--- a/docs/1.0. Authorization Practice.md
+++ b/docs/1.0. Authorization Practice.md
@@ -1,4 +1,8 @@
 # AMWA BCP-003-02: Authorization in NMOS Systems \[Work In Progress\]
+{:.no_toc}
+
+* A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
 
 Please see the IS-10 Specification at [NMOS Authorization][IS-10] for further details regarding implementing
 authorization with the NMOS suite of APIs.


### PR DESCRIPTION
(Note: these don't appear on GitHub MarkDown preview, only in the final render on specs.amwa.tv.)